### PR TITLE
Display song title as Discord status for bot user

### DIFF
--- a/src/DankDitties/DiscordClient.cs
+++ b/src/DankDitties/DiscordClient.cs
@@ -38,6 +38,9 @@ namespace DankDitties
             _witAiClient = witAiClient;
             _metadataManager = metadataManager;
             _playHistoryManager = playHistoryManager;
+
+            if (_voiceChannelWorker != null)
+                _voiceChannelWorker.OnNextSong += SetPresenceForSong;
         }
 
         private Task OnReady()
@@ -52,6 +55,14 @@ namespace DankDitties
             };
             _voiceChannelWorker.Start();
             return Task.FromResult(0);
+        }
+
+        private async void SetPresenceForSong(object? sender, Metadata? songMetadata)
+        {
+            if (songMetadata != null)
+                await _client.SetActivityAsync(new Game(songMetadata.Title, ActivityType.Listening));
+            else
+                await _client.SetActivityAsync(null);
         }
 
         private async Task OnMessageReceived(SocketMessage arg)

--- a/src/DankDitties/VoiceChannelWorker.cs
+++ b/src/DankDitties/VoiceChannelWorker.cs
@@ -22,12 +22,25 @@ namespace DankDitties
         private readonly WitAiClient _witAiClient;
         private readonly List<string> _playlist = new List<string>();
         private readonly Random _random = new Random();
-
+        
         private Track? _mainTrack;
         private Track? _ttsTrack;
 
         public IEnumerable<string> Playlist => _playlist;
-        public Metadata? CurrentSong { get; private set; }
+        private Metadata? _currentSong;
+        public Metadata? CurrentSong
+        {
+            get
+            {
+                return _currentSong;
+            }
+            private set
+            {
+                _currentSong = value;
+                OnNextSong?.Invoke(this, _currentSong);
+            }
+        }
+        public event EventHandler<Metadata?>? OnNextSong;
 
         public VoiceChannelWorker(SocketVoiceChannel voiceChannel, MetadataManager metadataManager, PlayHistoryManager playHistoryManager, WitAiClient witAiClient)
         {


### PR DESCRIPTION
Displays the title of the current song as the bot's Discord status, i.e., `Listening to: Neil Cicierega - Piss`

Needs testing. I haven't figured out how to run the bot locally yet.